### PR TITLE
Add condition to removing old files in preinstall

### DIFF
--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -37,4 +37,6 @@ if [ -d ${MUNKICON_ROOT} ]; then
 fi
 
 # -- Old 'com.github.carlashley.munkicon'
-/bin/rm -f ${CONDITIONS_ROOT}/com.github.carlashley.*.py 2>/dev/null
+if ls ${CONDITIONS_ROOT}/com.github.carlashley.*.py &> /dev/null; then
+    /bin/rm -f ${CONDITIONS_ROOT}/com.github.carlashley.*.py 2>/dev/null
+fi


### PR DESCRIPTION
The attempt to remove old .py files fails if there are none to remove and causes the installation to fail during the preinstall script exiting with a non-zero code.

This checks to see if there are files to delete first.